### PR TITLE
Mailgun exception handling

### DIFF
--- a/apps/chat/src/app/api/typing.d.ts
+++ b/apps/chat/src/app/api/typing.d.ts
@@ -10,6 +10,7 @@ export enum ResponseStatus {
   contentBlock,
   wrongPassword,
   unknownError,
+  upstreamServiceFailure
 }
 
 export enum ReturnStatus {

--- a/apps/chat/src/app/api/user/register/code/route.ts
+++ b/apps/chat/src/app/api/user/register/code/route.ts
@@ -21,13 +21,24 @@ export async function GET(req: NextRequest): Promise<Response> {
 
   switch (codeData.status) {
     case RegisterReturnStatus.Success:
-      await sendEmail(email, codeData?.code);
-      // @ts-ignore
-      delete codeData.code;
-      return NextResponse.json({
-        status: ResponseStatus.Success,
-        code_data: codeData,
-      });
+      try {
+        await sendEmail(email, codeData?.code);
+        // @ts-ignore
+        delete codeData.code;
+        return NextResponse.json({
+          status: ResponseStatus.Success,
+          code_data: codeData,
+        });
+      } catch(e) {
+        if(e instanceof Error) {
+          return NextResponse.json({ status: ResponseStatus.upstreamServiceFailure, message: e.message }, { status: 500 });
+        } else {
+          return NextResponse.json(
+            { status: ResponseStatus.unknownError, },
+            { status: 500 }
+          );
+        }
+      }
     case RegisterReturnStatus.AlreadyRegister:
       return NextResponse.json({ status: ResponseStatus.alreadyExisted });
     case RegisterReturnStatus.TooFast:

--- a/apps/chat/src/app/api/user/register/code/route.ts
+++ b/apps/chat/src/app/api/user/register/code/route.ts
@@ -30,13 +30,12 @@ export async function GET(req: NextRequest): Promise<Response> {
           code_data: codeData,
         });
       } catch(e) {
+        // TODO: delete the code in db (because the code is not sent to user,
+        // not deleting will prevent generating new code for this email next time before the code is expired)
         if(e instanceof Error) {
           return NextResponse.json({ status: ResponseStatus.upstreamServiceFailure, message: e.message }, { status: 500 });
         } else {
-          return NextResponse.json(
-            { status: ResponseStatus.unknownError, },
-            { status: 500 }
-          );
+          return NextResponse.json({ status: ResponseStatus.unknownError, }, { status: 500 });
         }
       }
     case RegisterReturnStatus.AlreadyRegister:

--- a/apps/chat/src/app/register/page.tsx
+++ b/apps/chat/src/app/register/page.tsx
@@ -102,7 +102,7 @@ export default function Register() {
       case ResponseStatus.Success: {
         switch (res.code_data.status) {
           case 0:
-            showToast("验证码成功发送!");
+            showToast(Locales.Index.VeriCodeSent);
             setIsSending(true);
             break;
           case 1:

--- a/apps/chat/src/app/register/page.tsx
+++ b/apps/chat/src/app/register/page.tsx
@@ -35,7 +35,7 @@ export default function Register() {
   const handleRegister = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    if (!email || !password || !verificationCode) {
+    if (!email || !password || (ifVerifyCode && !verificationCode)) {
       showToast(Locales.Index.NoneData);
       setSubmitting(false);
       return;

--- a/apps/chat/src/app/register/page.tsx
+++ b/apps/chat/src/app/register/page.tsx
@@ -109,7 +109,7 @@ export default function Register() {
             showToast(Locales.Index.DuplicateRegistration);
             break;
           case 2:
-            showToast("请求验证码过快，请稍后再试!");
+            showToast(Locales.Index.RequestVeriCodeTooFrequently);
             break;
           case 4:
           default:
@@ -122,8 +122,12 @@ export default function Register() {
         showToast(Locales.Index.EmailNonExistent);
         break;
       }
+      case ResponseStatus.tooFast: {
+        showToast(Locales.Index.RequestVeriCodeTooFrequently);
+        break;
+      }
       default: {
-        showToast(Locales.UnknownError);
+        showToast("请求验证码过快，请稍后再试!");
         break;
       }
     }

--- a/apps/chat/src/app/register/page.tsx
+++ b/apps/chat/src/app/register/page.tsx
@@ -97,7 +97,7 @@ export default function Register() {
         }
       )
     ).json();
-
+    
     switch (res.status) {
       case ResponseStatus.Success: {
         switch (res.code_data.status) {
@@ -124,6 +124,11 @@ export default function Register() {
       }
       case ResponseStatus.tooFast: {
         showToast(Locales.Index.RequestVeriCodeTooFrequently);
+        break;
+      }
+      case ResponseStatus.upstreamServiceFailure: {
+        // more info about failure is in res.message
+        showToast(Locales.Index.FailToSendEmail);
         break;
       }
       default: {

--- a/apps/chat/src/app/register/page.tsx
+++ b/apps/chat/src/app/register/page.tsx
@@ -127,7 +127,7 @@ export default function Register() {
         break;
       }
       default: {
-        showToast("请求验证码过快，请稍后再试!");
+        showToast(Locales.UnknownError);
         break;
       }
     }

--- a/apps/chat/src/lib/email/elasticemail.ts
+++ b/apps/chat/src/lib/email/elasticemail.ts
@@ -24,5 +24,9 @@ export default async function sendEmail(to: string, code: string | number) {
     body: formData,
   });
 
-  return response.ok;
+  if (response.ok) {
+    return true;
+  } else {
+    throw new Error(`elasticemail api error: code ${response.status}, ${response.body}`);
+  }
 }

--- a/apps/chat/src/lib/email/mailgun.ts
+++ b/apps/chat/src/lib/email/mailgun.ts
@@ -29,5 +29,9 @@ export default async function sendEmail(
     body: formData.toString(),
   });
 
-  return response.ok;
+  if (response.ok) {
+    return true;
+  } else {
+    throw new Error(`mailgun api error: code ${response.status}, ${response.body}`);
+  }
 }

--- a/apps/chat/src/lib/email/stmpjs.ts
+++ b/apps/chat/src/lib/email/stmpjs.ts
@@ -48,6 +48,6 @@ export default async function sendEmail(to: string, code: string | number) {
     console.log(await response.text());
     return true;
   } else {
-    throw new Error("Network response was not ok.");
+    throw new Error(`stmpjs api error: code ${response.status}, ${response.body}`);
   }
 }

--- a/apps/chat/src/locales/cn.ts
+++ b/apps/chat/src/locales/cn.ts
@@ -20,6 +20,7 @@ const cn = {
     DuplicateRegistration: "该邮箱已被注册",
     CodeError: "验证码错误",
     PasswordError: "密码错误",
+    RequestVeriCodeTooFrequently: "请求验证码过快，请稍后再试!"
   },
   UnknownError: "未知错误，请联系管理员",
   WIP: "该功能仍在开发中……",

--- a/apps/chat/src/locales/cn.ts
+++ b/apps/chat/src/locales/cn.ts
@@ -21,7 +21,8 @@ const cn = {
     CodeError: "验证码错误",
     PasswordError: "密码错误",
     RequestVeriCodeTooFrequently: "请求验证码过快，请稍后再试!",
-    VeriCodeSent: "验证码成功发送!"
+    VeriCodeSent: "验证码成功发送!",
+    FailToSendEmail: "验证码发送失败"
   },
   UnknownError: "未知错误，请联系管理员",
   WIP: "该功能仍在开发中……",

--- a/apps/chat/src/locales/cn.ts
+++ b/apps/chat/src/locales/cn.ts
@@ -20,7 +20,8 @@ const cn = {
     DuplicateRegistration: "该邮箱已被注册",
     CodeError: "验证码错误",
     PasswordError: "密码错误",
-    RequestVeriCodeTooFrequently: "请求验证码过快，请稍后再试!"
+    RequestVeriCodeTooFrequently: "请求验证码过快，请稍后再试!",
+    VeriCodeSent: "验证码成功发送!"
   },
   UnknownError: "未知错误，请联系管理员",
   WIP: "该功能仍在开发中……",


### PR DESCRIPTION
#82 
上游邮件服务出错时，将原始错误码和错误信息返回，并添加了一个新的ResponseType（upstreamServiceFailure）用于表示上游服务错误

顺便修复了一个没有配置邮件服务时，注册页的输入校验永远无法通过的问题